### PR TITLE
Filter panel

### DIFF
--- a/lib/rack/bug/autoloading.rb
+++ b/lib/rack/bug/autoloading.rb
@@ -19,6 +19,7 @@ class Rack::Bug
   autoload :RequestVariablesPanel,  "rack/bug/panels/request_variables_panel"
   autoload :SQLPanel,               "rack/bug/panels/sql_panel"
   autoload :TemplatesPanel,         "rack/bug/panels/templates_panel"
+  autoload :FiltersPanel,           "rack/bug/panels/filters_panel"
   autoload :TimerPanel,             "rack/bug/panels/timer_panel"
   autoload :SphinxPanel,            "rack/bug/panels/sphinx_panel"
 end

--- a/lib/rack/bug/options.rb
+++ b/lib/rack/bug/options.rb
@@ -78,6 +78,7 @@ class Rack::Bug
           ActiveRecordPanel,
           CachePanel,
           TemplatesPanel,
+          FiltersPanel,
           LogPanel,
           MemoryPanel
         ]

--- a/lib/rack/bug/panels/filters_panel.rb
+++ b/lib/rack/bug/panels/filters_panel.rb
@@ -1,0 +1,44 @@
+module Rack
+  class Bug
+
+    class FiltersPanel < Panel
+      require "rack/bug/panels/filters_panel/action_controller_extension"
+
+      autoload :Trace,      "rack/bug/panels/filters_panel/trace"
+      autoload :Rendering,  "rack/bug/panels/filters_panel/rendering"
+
+      def self.record(filter, &block)
+        return block.call unless Rack::Bug.enabled?
+
+        filter_trace.start(filter)
+        result = block.call
+        filter_trace.finished(filter)
+        return result
+      end
+
+      def self.reset
+        Thread.current["rack.bug.filter_trace"] = Trace.new
+      end
+
+      def self.filter_trace
+        Thread.current["rack.bug.filter_trace"] ||= Trace.new
+      end
+
+      def name
+        "filters"
+      end
+
+      def heading
+        "Filters: %.2fms" % (self.class.filter_trace.total_time * 1_000)
+      end
+
+      def content
+        result = render_template "panels/filters", :filter_trace => self.class.filter_trace
+        self.class.reset
+        return result
+      end
+
+    end
+
+  end
+end

--- a/lib/rack/bug/panels/filters_panel/action_controller_extension.rb
+++ b/lib/rack/bug/panels/filters_panel/action_controller_extension.rb
@@ -1,0 +1,13 @@
+if defined?(ActionController) && defined?(ActionController::Filters::Filter)
+  
+  ActionController::Filters::Filter.class_eval do
+    
+    def call_with_rack_bug(*args, &block)
+      Rack::Bug::FiltersPanel.record(self) do
+        call_without_rack_bug(*args, &block)
+      end
+    end
+    
+    alias_method_chain :call, :rack_bug
+  end
+end

--- a/lib/rack/bug/panels/filters_panel/rendering.rb
+++ b/lib/rack/bug/panels/filters_panel/rendering.rb
@@ -1,0 +1,72 @@
+module Rack
+  class Bug
+    class FiltersPanel
+
+      class Rendering
+        attr_accessor :name
+        attr_accessor :start_time
+        attr_accessor :end_time
+        attr_accessor :parent
+        attr_reader :children
+
+
+        def initialize(filter)
+          name = filter
+          unless filter.is_a?(String)
+            name = filter.class.to_s.split('::').last.underscore
+            name += ' - ' + filter.method.to_s.escape_html if filter.respond_to?(:method)
+          end
+          @name = name
+          @children = []
+        end
+
+        def add(rendering)
+          @children << rendering
+          rendering.parent = self
+        end
+
+        def time
+          @end_time - @start_time
+        end
+
+        def exclusive_time
+          time - child_time
+        end
+
+        def child_time
+          children.inject(0.0) { |memo, c| memo + c.time }
+        end
+
+        def time_summary
+          if children.any?
+            "%.2fms, %.2f exclusive" % [time * 1_000, exclusive_time * 1_000]
+          else
+            "%.2fms" % (time * 1_000)
+          end
+        end
+        def html
+          <<-HTML
+            <li>
+              <p>#{name} (#{time_summary})</p>
+
+              #{children_html}
+            </li>
+          HTML
+        end
+
+        def children_html
+          return "" unless children.any?
+
+          <<-HTML
+            <ul>#{joined_children_html}</ul>
+          HTML
+        end
+
+        def joined_children_html
+          children.map { |c| c.html }.join
+        end
+      end
+
+    end
+  end
+end

--- a/lib/rack/bug/panels/filters_panel/trace.rb
+++ b/lib/rack/bug/panels/filters_panel/trace.rb
@@ -1,0 +1,35 @@
+module Rack
+  class Bug
+    class FiltersPanel
+
+      class Trace
+
+        def start(filter)
+          
+          rendering = Rendering.new(filter)
+          rendering.start_time = Time.now
+          @current.add(rendering)
+          @current = rendering
+        end
+
+        def finished(filter)
+          @current.end_time = Time.now
+          @current = @current.parent
+        end
+
+        def initialize
+          @current = root
+        end
+
+        def total_time
+          root.child_time
+        end
+
+        def root
+          @root ||= Rendering.new("root")
+        end
+      end
+
+    end
+  end
+end

--- a/lib/rack/bug/views/panels/filters.html.erb
+++ b/lib/rack/bug/views/panels/filters.html.erb
@@ -1,0 +1,7 @@
+<h3>Filters</h3>
+
+<ul>
+  <% filter_trace.root.children.each do |child| %>
+    <%= child.html %>
+  <% end %>
+</ul>

--- a/spec/rack/bug/panels/filters_panel_spec.rb
+++ b/spec/rack/bug/panels/filters_panel_spec.rb
@@ -1,0 +1,25 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../../spec_helper')
+
+class Rack::Bug
+  describe FiltersPanel do
+    before do
+      FiltersPanel.reset
+      rack_env "rack-bug.panel_classes", [FiltersPanel]
+    end
+
+    describe "heading" do
+      it "displays the total rendering time" do
+        response = get_via_rack "/"
+        response.should have_heading("Filters: 0.00ms")
+      end
+    end
+
+    describe "content" do
+      it "displays the filter paths" do
+        FiltersPanel.record("some_filter") { }
+        response = get_via_rack "/"
+        response.should contain("some_filter")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,

The branch at http://github.com/ketan/rack-bug/tree/filter-panel contains some support for rendering the timings on rails before/after/around filters.

I understand that this may not quite be upto any rack-bug standards, so I'm open to any feedback to help improve this patch.

Thanks for a great plugin!

-- Ketan
