### PR TITLE
Bugfix for Rails 2.3.8 under Ruby 1.9.1 or 1.9.2

### DIFF
--- a/lib/rack/bug/filtered_backtrace.rb
+++ b/lib/rack/bug/filtered_backtrace.rb
@@ -19,7 +19,7 @@ module Rack
 
       def root_for_backtrace_filtering(sub_path = nil)
         if defined?(Rails) && Rails.respond_to?(:root)
-          sub_path ? Rails.root.join(sub_path) : Rails.root
+          sub_path ? Rails.root.join(sub_path).to_s : Rails.root.to_s
         else
           root = if defined?(RAILS_ROOT)
             RAILS_ROOT


### PR DESCRIPTION
Environment details:

```
$ ruby --version
ruby 1.9.2p0 (2010-08-18 revision 29036) [i686-linux]
$ rails --version
Rails 2.3.8
```

In `lib/rack/bug/filtered_backtrace.rb`, the `root_for_backtrace_filtering` method uses `Rails.root` if available. This returns a `Pathname` instead of a `String` in Rails 2.3.8 under both Ruby 1.9.1 and 1.9.2. This causes a `type mismatch: Pathname given` exception in the `filtered_backtrace` method.

I've patched the `root_for_backtrace_filtering` method to explicitly convert `Rails.root` to a string, stopping this exception from being raised.
