### PR TITLE
Ruby 1.9.2 / UTF-8 / Content-Length

### DIFF
--- a/lib/rack/bug/toolbar.rb
+++ b/lib/rack/bug/toolbar.rb
@@ -45,7 +45,7 @@ module Rack
         full_body = @response.body.join
         full_body.sub! /<\/body>/, render + "</body>"
 
-        @response["Content-Length"] = full_body.bytesize.to_s
+        @response["Content-Length"] = Rack::Utils.bytesize(full_body).to_s
 
         # Ensure that browser does
         @response["Etag"] = ""

--- a/lib/rack/bug/toolbar.rb
+++ b/lib/rack/bug/toolbar.rb
@@ -45,7 +45,7 @@ module Rack
         full_body = @response.body.join
         full_body.sub! /<\/body>/, render + "</body>"
 
-        @response["Content-Length"] = full_body.size.to_s
+        @response["Content-Length"] = full_body.bytesize.to_s
 
         # Ensure that browser does
         @response["Etag"] = ""

--- a/spec/fixtures/sample_app.rb
+++ b/spec/fixtures/sample_app.rb
@@ -26,6 +26,10 @@ class SampleApp < Sinatra::Base
     raise "Error!"
   end
 
+  get "/utf8" do
+    "2πr"
+  end
+
   get "/" do
     if params[:content_type]
       headers["Content-Type"] = params[:content_type]
@@ -40,7 +44,6 @@ class SampleApp < Sinatra::Base
           <p><a href="__rack_bug__/bookmarklet.html">Page with bookmarklet for enabling Rack::Bug</a></p>
           <p><a href="/redirect">Page with a redirect - turn on intercept_redirects to see Rack::Bug catch it</a></p>
           <p><a href="/error">Page with an error to check rack-bug not rescuing errors</a></p>
-          <p>И наконец, не забываем про UTF-8</p>
         </body>
       </html>
     HTML

--- a/spec/fixtures/sample_app.rb
+++ b/spec/fixtures/sample_app.rb
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 $LOAD_PATH.unshift File.dirname(__FILE__) + '/../../lib'
 require "rack/bug"
 
@@ -38,6 +40,7 @@ class SampleApp < Sinatra::Base
           <p><a href="__rack_bug__/bookmarklet.html">Page with bookmarklet for enabling Rack::Bug</a></p>
           <p><a href="/redirect">Page with a redirect - turn on intercept_redirects to see Rack::Bug catch it</a></p>
           <p><a href="/error">Page with an error to check rack-bug not rescuing errors</a></p>
+          <p>И наконец, не забываем про UTF-8</p>
         </body>
       </html>
     HTML

--- a/spec/rack/toolbar_spec.rb
+++ b/spec/rack/toolbar_spec.rb
@@ -8,7 +8,12 @@ describe Rack::Bug do
 
   it "updates the Content-Length" do
     response = get "/"
-    response["Content-Length"].should == response.body.bytesize.to_s
+    response["Content-Length"].should == response.body.size.to_s
+  end
+
+  it "updates the Content-Length properly for UTF-8" do
+    response = get "/utf8"
+    response["Content-Length"].should == "4"
   end
 
   it "serves the Rack::Bug assets under /__rack_bug__/" do

--- a/spec/rack/toolbar_spec.rb
+++ b/spec/rack/toolbar_spec.rb
@@ -8,7 +8,7 @@ describe Rack::Bug do
 
   it "updates the Content-Length" do
     response = get "/"
-    response["Content-Length"].should == response.body.size.to_s
+    response["Content-Length"].should == response.body.bytesize.to_s
   end
 
   it "serves the Rack::Bug assets under /__rack_bug__/" do


### PR DESCRIPTION
Fixes "Content-Length header was X, but should be Y" error.
