### PR TITLE
Fix for a bug exposed in Ruby 1.9 

### DIFF
--- a/lib/rack/bug/filtered_backtrace.rb
+++ b/lib/rack/bug/filtered_backtrace.rb
@@ -31,7 +31,7 @@ module Rack
             nil
           end
           sub_path ? ::File.join(root, sub_path) : root
-        end
+        end.to_s
       end
     end
   end


### PR DESCRIPTION
```
$ rvm use 1.8.7
$ irb
>> require 'pathname'
=> true
>> 'asdasdas'.index(Pathname.new('dada'))
=> nil

$ rvm use 1.9.1
$ irb
>> require 'pathname'
=> true
>> 'asdasdas'.index(Pathname.new('dada'))
TypeError: type mismatch: Pathname given
from (irb):2:in `index'
from (irb):2
```
