### PR TITLE
Prevent etags from matching when the toolbar might be inserted.

### DIFF
--- a/lib/rack/bug/panels/memory_panel.rb
+++ b/lib/rack/bug/panels/memory_panel.rb
@@ -17,9 +17,9 @@ module Rack
             mem = wproc.WorkingSetSize
           end
           mem.to_i / 1000
-        elsif pages = File.read("/proc/self/statm") rescue nil
+        elsif pages = ::File.read("/proc/self/statm") rescue nil
           pages.to_i * statm_page_size
-        elsif proc_file = File.new("/proc/#{$$}/smaps") rescue nil
+        elsif proc_file = ::File.new("/proc/#{$$}/smaps") rescue nil
           proc_file.map do |line|
             size = line[/Size: *(\d+)/, 1] and size.to_i
           end.compact.sum

--- a/lib/rack/bug/panels/memory_panel.rb
+++ b/lib/rack/bug/panels/memory_panel.rb
@@ -1,15 +1,44 @@
-#
+begin
+  require 'win32ole'
+rescue LoadError
+end
+
 module Rack
   class Bug
 
     class MemoryPanel < Panel
 
+      def get_memory_usage
+        if defined? WIN32OLE
+          wmi = WIN32OLE.connect("winmgmts:root/cimv2")
+          mem = 0
+          query = "select * from Win32_Process where ProcessID = #{$$}"
+          wmi.ExecQuery(query).each do |wproc|
+            mem = wproc.WorkingSetSize
+          end
+          mem.to_i / 1000
+        elsif pages = File.read("/proc/self/statm") rescue nil
+          pages.to_i * statm_page_size
+        elsif proc_file = File.new("/proc/#{$$}/smaps") rescue nil
+          proc_file.map do |line|
+            size = line[/Size: *(\d+)/, 1] and size.to_i
+          end.compact.sum
+        else
+          `ps -o vsz= -p #{$$}`.to_i
+        end
+      end
+
+      # try to get and cache memory page size. falls back to 4096.
+      def statm_page_size
+        @statm_page_size ||= (`getconf PAGESIZE`.strip.to_i rescue 4096) / 1024
+      end
+
       def before(env)
-        @original_memory = `ps -o rss= -p #{$$}`.to_i
+        @original_memory = get_memory_usage
       end
 
       def after(env, status, headers, body)
-        @total_memory = `ps -o rss= -p #{$$}`.to_i
+        @total_memory = get_memory_usage
         @memory_increase = @total_memory - @original_memory
       end
 

--- a/lib/rack/bug/panels/sql_panel/sql_extension.rb
+++ b/lib/rack/bug/panels/sql_panel/sql_extension.rb
@@ -9,3 +9,11 @@ if defined?(ActiveRecord) &&  defined?(ActiveRecord::ConnectionAdapters)
     alias_method_chain :log, :rack_bug
   end
 end
+
+class Mysql
+  class Result
+    def fields
+      fetch_fields.each {|f| yield f.name }
+    end
+  end
+end

--- a/lib/rack/bug/toolbar.rb
+++ b/lib/rack/bug/toolbar.rb
@@ -13,6 +13,8 @@ module Rack
         @env = env
         @env["rack-bug.panels"] = []
 
+        @env.delete("HTTP_IF_NONE_MATCH")
+
         Rack::Bug.enable
         status, headers, body = builder.call(@env)
         Rack::Bug.disable

--- a/lib/rack/bug/views/panels/execute_sql.html.erb
+++ b/lib/rack/bug/views/panels/execute_sql.html.erb
@@ -13,8 +13,8 @@
 <table class="sortable">
   <thead>
     <tr>
-      <% result.fetch_fields.each do |field| %>
-        <th><%= field.name.upcase %></th>
+      <% result.fields.each do |field| %>
+        <th><%= field.upcase %></th>
       <% end %>
     </tr>
   </thead>

--- a/lib/rack/bug/views/panels/explain_sql.html.erb
+++ b/lib/rack/bug/views/panels/explain_sql.html.erb
@@ -13,8 +13,8 @@
 <table class="sortable">
   <thead>
     <tr>
-      <% result.fetch_fields.each do |field| %>
-        <th><%= field.name.upcase %></th>
+      <% result.fields.each do |field| %>
+        <th><%= field.upcase %></th>
       <% end %>
     </tr>
   </thead>

--- a/lib/rack/bug/views/panels/profile_sql.html.erb
+++ b/lib/rack/bug/views/panels/profile_sql.html.erb
@@ -13,8 +13,8 @@
 <table class="sortable">
   <thead>
     <tr>
-      <% result.fetch_fields.each do |field| %>
-        <th><%= field.name.upcase %></th>
+      <% result.fields.each do |field| %>
+        <th><%= field.upcase %></th>
       <% end %>
     </tr>
   </thead>

--- a/rack-bug.gemspec
+++ b/rack-bug.gemspec
@@ -28,11 +28,12 @@ Gem::Specification.new do |s|
     "lib/rack/bug/panels/active_record_panel.rb",
     "lib/rack/bug/panels/active_record_panel/activerecord_extensions.rb",
     "lib/rack/bug/panels/cache_panel.rb",
+    "lib/rack/bug/panels/cache_panel/dalli_extension.rb",
     "lib/rack/bug/panels/cache_panel/memcache_extension.rb",
     "lib/rack/bug/panels/cache_panel/panel_app.rb",
     "lib/rack/bug/panels/cache_panel/stats.rb",
     "lib/rack/bug/panels/log_panel.rb",
-    "lib/rack/bug/panels/log_panel/rails_extension.rb",
+    "lib/rack/bug/panels/log_panel/logger_extension.rb",
     "lib/rack/bug/panels/memory_panel.rb",
     "lib/rack/bug/panels/rails_info_panel.rb",
     "lib/rack/bug/panels/redis_panel.rb",
@@ -93,7 +94,7 @@ Gem::Specification.new do |s|
     "spec/rack/bug/panels/sql_panel_spec.rb",
     "spec/rack/bug/panels/templates_panel_spec.rb",
     "spec/rack/bug/panels/timer_panel_spec.rb",
-    "spec/rack/toolbar_spec.rb",
+    "spec/rack/bug_spec.rb",
     "spec/rcov.opts",
     "spec/spec.opts",
     "spec/spec_helper.rb"
@@ -115,7 +116,7 @@ Gem::Specification.new do |s|
     "spec/rack/bug/panels/sql_panel_spec.rb",
     "spec/rack/bug/panels/templates_panel_spec.rb",
     "spec/rack/bug/panels/timer_panel_spec.rb",
-    "spec/rack/toolbar_spec.rb",
+    "spec/rack/bug_spec.rb",
     "spec/spec_helper.rb"
   ]
 

--- a/spec/rack/bug/panels/sql_panel_spec.rb
+++ b/spec/rack/bug/panels/sql_panel_spec.rb
@@ -47,10 +47,9 @@ class Rack::Bug
 
     def stub_result(results = [[]])
       columns = results.first
-      fields = columns.map { |c| stub("field", :name => c) }
       rows = results[1..-1]
 
-      result = stub("result", :fetch_fields => fields)
+      result = stub("result", :fields => columns)
       result.stub!(:each).and_yield(*rows)
       return result
     end


### PR DESCRIPTION
There may be other headers to remove as well, but removing this one was all I needed. See issue #30

I also fixed the gemspec.
