### PR TITLE
Fix 'explain' and 'select' view for Postgresql and make backtrace info sortable

### DIFF
--- a/lib/rack/bug/public/__rack_bug__/bug.css
+++ b/lib/rack/bug/public/__rack_bug__/bug.css
@@ -170,7 +170,12 @@
   color: #000;
   vertical-align: top;
 }
-#rack_bug .panel_content table tr.odd td {
+
+#rack_bug .panel_content table tr:nth-child(even) td {
+  background: #fff;
+}
+
+#rack_bug .panel_content table tr:nth-child(odd) td {
   background: #eee;
 }
 
@@ -187,8 +192,7 @@
   margin-left: 10px;
 }
 
-#rack_bug .panel_content table tr.odd td.rack_bug_spinner,
-#rack_bug .panel_content table tr.even td.rack_bug_spinner,
+#rack_bug .panel_content table tr td.rack_bug_spinner,
 #rack_bug .panel_content table td.rack_bug_spinner,
 #rack_bug .rack_bug_spinner {
   background-image: url(/__rack_bug__/spinner.gif);

--- a/lib/rack/bug/public/__rack_bug__/bug.js
+++ b/lib/rack/bug/public/__rack_bug__/bug.js
@@ -30,7 +30,7 @@ jQuery(function($) {
         return false;
       });
       $('#rack_bug a.reveal_backtrace').click(function() {
-        $(this).parents("tr").next().toggle();
+        $(this).parents('tr').find('ul.backtrace').toggle();
         return false;
       });
       $('#rack_bug a.rack_bug_close').click(function() {

--- a/lib/rack/bug/views/panels/cache.html.erb
+++ b/lib/rack/bug/views/panels/cache.html.erb
@@ -57,7 +57,7 @@
     <tbody>
       <% i = 1 %>
       <% stats.queries.each do |query| %>
-        <tr class="<%= i % 2 == 0 ? "even" : "odd" %>">
+        <tr>
           <td><%= query.display_time %></td>
           <td><%= query.method %></td>
           <td><%= query.display_keys %></td>

--- a/lib/rack/bug/views/panels/execute_sql.html.erb
+++ b/lib/rack/bug/views/panels/execute_sql.html.erb
@@ -13,7 +13,7 @@
 <table class="sortable">
   <thead>
     <tr>
-      <% if defined?(Mysql2) %>
+      <% if defined?(Mysql2) || defined?(PGresult) %>
         <% result.fields.each do |field| %>
           <th><%= field.upcase %></th>
         <% end %>

--- a/lib/rack/bug/views/panels/execute_sql.html.erb
+++ b/lib/rack/bug/views/panels/execute_sql.html.erb
@@ -27,7 +27,7 @@
   <tbody>
     <% i = 1 %>
     <% result.each do |row| %>
-      <tr class="<%= i % 2 == 0 ? "even" : "odd" %>">
+      <tr>
         <% row.each do |value| %>
           <td><%= value %></td>
         <% end %>

--- a/lib/rack/bug/views/panels/explain_sql.html.erb
+++ b/lib/rack/bug/views/panels/explain_sql.html.erb
@@ -13,7 +13,7 @@
 <table class="sortable">
   <thead>
     <tr>
-      <% if defined?(Mysql2) %>
+      <% if defined?(Mysql2) || defined?(PGresult) %>
         <% result.fields.each do |field| %>
           <th><%= field.upcase %></th>
         <% end %>

--- a/lib/rack/bug/views/panels/explain_sql.html.erb
+++ b/lib/rack/bug/views/panels/explain_sql.html.erb
@@ -27,7 +27,7 @@
   <tbody>
     <% i = 1 %>
     <% result.each do |row| %>
-      <tr class="<%= i % 2 == 0 ? "even" : "odd" %>">
+      <tr>
         <% row.each do |value| %>
           <td><%= value %></td>
         <% end %>

--- a/lib/rack/bug/views/panels/log.html.erb
+++ b/lib/rack/bug/views/panels/log.html.erb
@@ -10,7 +10,7 @@
   <tbody>
     <% i = 1 %>
     <% logs.each do |entry| %>
-      <tr class="<%= i % 2 == 0 ? "even" : "odd" %>">
+      <tr>
         <td><%= entry.level %></td>
         <td><%= entry.time %>ms</td>
         <td><%= entry.cleaned_message %></td>

--- a/lib/rack/bug/views/panels/mongo.html.erb
+++ b/lib/rack/bug/views/panels/mongo.html.erb
@@ -21,7 +21,7 @@
     <tbody>
       <% i = 1 %>
       <% stats.queries.each do |query| %>
-        <tr class="<%= i % 2 == 0 ? "even" : "odd" %>">
+        <tr>
           <td><%= query.display_time %></td>
           <td><%= query.command %></td>
         </tr>

--- a/lib/rack/bug/views/panels/profile_sql.html.erb
+++ b/lib/rack/bug/views/panels/profile_sql.html.erb
@@ -13,7 +13,7 @@
 <table class="sortable">
   <thead>
     <tr>
-      <% if defined?(Mysql2) %>
+      <% if defined?(Mysql2) || defined?(PGresult) %>
         <% result.fields.each do |field| %>
           <th><%= field.upcase %></th>
         <% end %>

--- a/lib/rack/bug/views/panels/profile_sql.html.erb
+++ b/lib/rack/bug/views/panels/profile_sql.html.erb
@@ -27,7 +27,7 @@
   <tbody>
     <% i = 1 %>
     <% result.each do |row| %>
-      <tr class="<%= i % 2 == 0 ? "even" : "odd" %>">
+      <tr>
         <% row.each do |value| %>
           <td><%= value %></td>
         <% end %>

--- a/lib/rack/bug/views/panels/rails_info.html.erb
+++ b/lib/rack/bug/views/panels/rails_info.html.erb
@@ -9,7 +9,7 @@
   <tbody>
     <% i = 1 %>
     <% Rails::Info.properties.each do |key, val| %>
-      <tr class="<%= i % 2 == 0 ? "even" : "odd" %>">
+      <tr>
         <td><%=h key %></td>
         <td class="code"><div><%=h val %></div></td>
       </tr>

--- a/lib/rack/bug/views/panels/redis.html.erb
+++ b/lib/rack/bug/views/panels/redis.html.erb
@@ -22,7 +22,7 @@
     <tbody>
       <% i = 1 %>
       <% stats.queries.each do |query| %>
-        <tr class="<%= i % 2 == 0 ? "even" : "odd" %>">
+        <tr>
           <td><%= query.display_time %></td>
           <td><%= query.command %></td>
           <td><%= "<a href='#' class='reveal_backtrace'>Show Backtrace</a>" if query.has_backtrace? %></td>

--- a/lib/rack/bug/views/panels/request_variables.html.erb
+++ b/lib/rack/bug/views/panels/request_variables.html.erb
@@ -12,7 +12,7 @@
     <tbody>
       <% i = 1 %>
       <% sections[header].each do |key, val| %>
-        <tr class="<%= i % 2 == 0 ? "even" : "odd" %>">
+        <tr>
           <td><%=h key %></td>
           <td class="code"><div>
           <% if val.is_a?(Hash) %>

--- a/lib/rack/bug/views/panels/sphinx.html.erb
+++ b/lib/rack/bug/views/panels/sphinx.html.erb
@@ -21,7 +21,7 @@
     <tbody>
       <% i = 1 %>
       <% stats.queries.each do |query| %>
-        <tr class="<%= i % 2 == 0 ? "even" : "odd" %>">
+        <tr>
           <td><%= query.display_time %></td>
           <td><%= query.command %></td>
         </tr>

--- a/lib/rack/bug/views/panels/sql.html.erb
+++ b/lib/rack/bug/views/panels/sql.html.erb
@@ -11,26 +11,24 @@
   <tbody>
     <% i = 1 %>
     <% queries.each do |query| %>
-      <tr class="<%= i % 2 == 0 ? "even" : "odd" %>">
+      <tr>
         <td><%= query.human_time %></td>
-        <td class="syntax"><%= query.sql %></td>
-        <td>
-          <% if query.has_backtrace? %>
-            <a href="#" class="reveal_backtrace">Show Backtrace</a>
-          <% end %>
-        </td>
-        <td>
-          <% if query.inspectable? %>
-            <a href="/__rack_bug__/execute_sql?<%= signed_params("query" => query.sql, "time" => query.time) %>" class="remote_call">SELECT</a> |
-            <a href="/__rack_bug__/explain_sql?<%= signed_params("query" => query.sql, "time" => query.time) %>" class="remote_call">EXPLAIN</a> |
-            <a href="/__rack_bug__/profile_sql?<%= signed_params("query" => query.sql, "time" => query.time) %>" class="remote_call">Profile</a>
-          <% end %>
-        </td>
-      </tr>
-      <tr style="display:none">
-        <td></td>
-        <td colspan="3">
-          <ul>
+        <td class="syntax">
+          <%= query.sql %>
+          <div class='opts'>
+            <% if query.has_backtrace? %>
+              <a href="#" class="reveal_backtrace">Show Backtrace</a>
+            <% end %>
+            <% if query.inspectable? && query.has_backtrace? %>
+               | 
+            <% end %>
+            <% if query.inspectable? %>
+              <a href="/__rack_bug__/execute_sql?<%= signed_params("query" => query.sql, "time" => query.time) %>" class="remote_call">SELECT</a> |
+              <a href="/__rack_bug__/explain_sql?<%= signed_params("query" => query.sql, "time" => query.time) %>" class="remote_call">EXPLAIN</a> |
+              <a href="/__rack_bug__/profile_sql?<%= signed_params("query" => query.sql, "time" => query.time) %>" class="remote_call">Profile</a>
+            <% end %>
+          </div>
+          <ul style="display:none" class='backtrace'>
             <% query.filtered_backtrace.each do |line| %>
               <li><%=h line %></li>
             <% end %>

--- a/lib/rack/bug/views/panels/timer.html.erb
+++ b/lib/rack/bug/views/panels/timer.html.erb
@@ -9,7 +9,7 @@
   <tbody>
     <% i = 1 %>
     <% measurements.each do |key, val| %>
-      <tr class="<%= i % 2 == 0 ? "even" : "odd" %>">
+      <tr>
         <td><%=h key %></td>
         <td><%=h val %></td>
       </tr>


### PR DESCRIPTION
- Fix for Postgres:
  - result.fetch_fields does not work if using postgres as a database.
  - Similar to Mysql2, we have to use result.fields (if defined?(PGresult)).
- CSS and JS cleanup:
  - move 'explain', 'backtrace' etc. links to the left
  - also switch to CSS nth-element instead of odd/even classes.
  - move backtrace info out of own <tr/> into a div within the corresponding <td/> (that makes it sort stable.)
