### PR TITLE
Escape HTML in the "log panel"

### DIFF
--- a/lib/rack/bug/views/panels/log.html.erb
+++ b/lib/rack/bug/views/panels/log.html.erb
@@ -13,7 +13,7 @@
       <tr>
         <td><%= entry.level %></td>
         <td><%= entry.time %>ms</td>
-        <td><%= entry.cleaned_message %></td>
+        <td><%=h entry.cleaned_message %></td>
       </tr>
       <% i += 1 %>
     <% end %>

--- a/spec/rack/bug/panels/log_panel_spec.rb
+++ b/spec/rack/bug/panels/log_panel_spec.rb
@@ -21,6 +21,12 @@ class Rack::Bug
         response.should contain("This is a logged message")
         response.should contain("DEBUG")
       end
+
+      it 'HTML-escapes logs' do
+        LogPanel.record("This is a logged message with a <tag />", 0)
+        response = get_via_rack "/"
+        response.body.should include("This is a logged message with a &lt;tag /&gt;")
+      end
     end
     
     describe "Extended Logger" do


### PR DESCRIPTION
In a Rails 2.3 project without rails_xss, log messages containing HTML tags are inserted unescaped into the toolbar, corrupting the HTML.

This should fix it.
