### PR TITLE
Update README with install instructions for the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,17 @@ Features
 
 Rails quick start
 ---------------------------
+Install as a gem (recommended):
+
+    gem install rack-bug
+
+OR Install as a plugin:
 
     script/plugin install git://github.com/brynary/rack-bug.git
+
+If using the gem, add Rack::Bug to your Gemfile:
+
+    gem 'rack-bug', :require => 'rack/bug'
 
 In config/environments/development.rb, add:
 


### PR DESCRIPTION
There should be instructions to install rack/bug as a gem as well as a plugin. Even the docs in the wiki are outdated. Keeping it the README will ensure it stays up-to-date.
